### PR TITLE
feat: configure prefix path for image-store

### DIFF
--- a/infra/services/image-store/ingress.yaml
+++ b/infra/services/image-store/ingress.yaml
@@ -8,7 +8,7 @@ spec:
   rules:
     - http:
         paths:
-          - path: /images
+          - path: /image-api/images
             pathType: Prefix
             backend:
               service:

--- a/infra/services/image-store/ingress.yaml
+++ b/infra/services/image-store/ingress.yaml
@@ -8,7 +8,7 @@ spec:
   rules:
     - http:
         paths:
-          - path: /image-api/images
+          - path: /image-api
             pathType: Prefix
             backend:
               service:

--- a/src/svc/image-store/Dockerfile
+++ b/src/svc/image-store/Dockerfile
@@ -31,4 +31,5 @@ WORKDIR /app
 COPY --from=publish /app/publish .
 
 COPY --from=build /app/Images /app/Images
+RUN chmod -R $APP_UID:$APP_GID /app/Images  
 ENTRYPOINT ["dotnet", "ImageStoreAPI.dll"]

--- a/src/svc/image-store/Program.cs
+++ b/src/svc/image-store/Program.cs
@@ -24,7 +24,9 @@ app.UseStaticFiles(new StaticFileOptions
     RequestPath = "/images"
 });
 
-app.MapGet("/images", async (HttpContext context) =>
+var image = app.MapGroup("/image-api");
+
+image.MapGet("images", async (HttpContext context) =>
 {
     var imagesPath = Path.Combine(builder.Environment.ContentRootPath, "Images");
 
@@ -36,14 +38,18 @@ app.MapGet("/images", async (HttpContext context) =>
 
     return Results.Ok(imageFiles);
 })
-.WithName("GetImageLinks")
-.WithOpenApi();
+.WithName("GetImageLinks");
 
-app.MapPost("/images", async (IFormFile file, string ?fileName, HttpRequest request) =>
+image.MapPost("", async (IFormFile? file, string? fileName, HttpRequest request) =>
 {
     if(string.IsNullOrEmpty(fileName))
     {
         return Results.BadRequest("File name is required. Please try again!");
+    }
+
+    if(file == null || file.Length == 0)
+    {
+        return Results.BadRequest("File is required. Please try again!");
     }
 
     var imagesPath = Path.Combine(builder.Environment.ContentRootPath, "Images");
@@ -63,12 +69,11 @@ app.MapPost("/images", async (IFormFile file, string ?fileName, HttpRequest requ
     return Results.Ok(imgUrl);
 })
 .WithName("PostImage")
-//.WithOpenApi()
 .DisableAntiforgery();
 
 app.UseStatusCodePagesWithRedirects("/errors/{0}");
 
-app.MapGet("/errors/404", async (HttpContext context) =>
+image.MapGet("errors/404", async (HttpContext context) =>
 {
 
     using HttpClient client = new();


### PR DESCRIPTION
Adding `MapGroup` for image-store endpoints to allow to prefixing with `image-api`
Updated ingress for image store to match new `image-api` prefix