### PR TITLE
feat: setup pipeline

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,7 +1,7 @@
 name: Pull Request Check
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,51 @@
+name: Pull Request Check
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  check_changes:
+    name: Check for changed services in src/svc
+    runs-on: ubuntu-latest
+    outputs:
+      changed_services: ${{ steps.get_changes.outputs.all_modified_files }}
+      has_changes: ${{ steps.get_changes.outputs.any_modified }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Get changed module directories
+        id: get_changes
+        uses: tj-actions/changed-files@v46
+        with:
+          path: ./src/svc
+          dir_names: true
+          dir_names_max_depth: 1
+          json: true
+          escape_json: false
+      - name: Print changed services
+        run: |
+          echo "${{ steps.get_changes.outputs.all_modified_files }}"
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: check_changes
+    if: ${{ needs.check_changes.outputs.has_changes == 'true' }}
+    permissions:
+      contents: write # to be able to publish a GitHub release
+      issues: write # to be able to comment on released issues
+      pull-requests: write # to be able to comment on released pull requests
+      id-token: write # to enable use of OIDC for npm provenance
+    strategy:
+      fail-fast: false
+      matrix:
+        service: ${{ fromJson(needs.check_changes.outputs.changed_services) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build docker image
+        working-directory: ./src/svc/${{ matrix.service }}
+        run: docker build -t ghcr.io/sofushn/ruc-workshop-dds-project .

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -48,4 +48,4 @@ jobs:
         uses: actions/checkout@v4
       - name: Build docker image
         working-directory: ./src/svc/${{ matrix.service }}
-        run: docker build -t ghcr.io/sofushn/ruc-workshop-dds-project .
+        run: docker build -t ghcr.io/sofushn/ruc-workshop-dds-project --label "org.opencontainers.image.source=https://github.com/sofushn/ruc-workshop-dds-project" .

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Build docker image
         working-directory: ./src/svc/${{ matrix.service }}
-        run: docker build -t ghcr.io/sofushn/ruc-workshop-dds-project .
+        run: docker build -t ghcr.io/sofushn/ruc-workshop-dds-project --label "org.opencontainers.image.source=https://github.com/sofushn/ruc-workshop-dds-project" .
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,66 @@
+name: Service Release
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  check_changes:
+    name: Check for changed services in src/svc
+    runs-on: ubuntu-latest
+    outputs:
+      changed_services: ${{ steps.get_changes.outputs.all_modified_files }}
+      has_changes: ${{ steps.get_changes.outputs.any_modified }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Get changed module directories
+        id: get_changes
+        uses: tj-actions/changed-files@v46
+        with:
+          path: ./src/svc
+          dir_names: true
+          dir_names_max_depth: 1
+          json: true
+          escape_json: false
+      - name: Print changed services
+        run: |
+          echo "${{ steps.get_changes.outputs.all_modified_files }}"
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: check_changes
+    if: ${{ needs.check_changes.outputs.has_changes == 'true' }}
+    permissions:
+      contents: write # to be able to publish a GitHub release
+    strategy:
+      fail-fast: false
+      matrix:
+        service: ${{ fromJson(needs.check_changes.outputs.changed_services) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build docker image
+        working-directory: ./src/svc/${{ matrix.service }}
+        run: docker build -t ghcr.io/sofushn/ruc-workshop-dds-project .
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*' # Use the latest Long Term Support version of Node.js
+      - name: Install Semantic Release
+        run: npm install -g semantic-release @semantic-release-plus/docker conventional-changelog-conventionalcommits
+      - name: Run semantic-release
+        working-directory: ./src/svc/${{ matrix.service }}
+        run: |
+          cp ${{ github.workspace }}/package.json .
+          semantic-release -d -t v${{ matrix.service }}-'${version}'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCKER_USERNAME: ${{ github.actor }}
+          DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "release": {
+    "branches": [
+      "main"
+    ],
+    "plugins": [
+      [
+        "@semantic-release/commit-analyzer",
+        {
+          "preset": "conventionalcommits"
+        }
+      ],
+      [
+        "@semantic-release-plus/docker",
+        {
+          "name": "ghcr.io/sofushn/ruc-workshop-dds-project",
+          "registry": "ghcr.io",
+          "publishChannelTag": false
+        }
+      ]
+    ]
+  },
+  "dependencies": {
+    "semantic-release": "^24.0.0",
+    "conventional-changelog-conventionalcommits": "^8.0.0",
+    "semantic-release-commit-filter": "^1.0.0",
+    "@semantic-release-plus/docker": "^3.1.0"
+  }
+}


### PR DESCRIPTION
Setup automatic build of services

Needs to be merged to main before it can be tested

## Explanation

This PR is the initial setup of a [GitHub workflow pipeline](https://docs.github.com/en/actions/writing-workflows/quickstart) that automatically builds each service if any changes is detected in its subfolder (e.g. changes to `src/svc/**`). The pipeline uses a tool called [semantic-release](https://github.com/semantic-release/semantic-release) that looks at all commits for a PR and pushes a new version of the related container image based on commit messages ([conventional commits](https://www.conventionalcommits.org/en/v1.0.0/))

There are two pipeline files, one for PR's and one for merging to main. Releases are only made when pushing to main. however, when opening a new PR a `docker build` is made to check if the image can be built.