### PR TITLE
fix: Adding correct ownership to image-store docker container

### DIFF
--- a/src/svc/image-store/Dockerfile
+++ b/src/svc/image-store/Dockerfile
@@ -1,35 +1,31 @@
-# See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
-
-# This stage is used when running from VS in fast mode (Default for Debug configuration)
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
-USER $APP_UID
 WORKDIR /app
 EXPOSE 8080
 EXPOSE 8081
 
-# This stage is used to build the service project
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["ImageStoreAPI.csproj", "."]
 RUN dotnet restore "./ImageStoreAPI.csproj"
 COPY . .
-
-COPY Images /app/Images
-RUN chmod 777 /app/Images
-RUN chown -R $APP_UID /app/Images
-
 RUN dotnet build "./ImageStoreAPI.csproj" -c $BUILD_CONFIGURATION -o /app/build
 
-# This stage is used to publish the service project to be copied to the final stage
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
 RUN dotnet publish "./ImageStoreAPI.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
 
-# This stage is used in production or when running from VS in regular mode (Default when not using the Debug configuration)
 FROM base AS final
 WORKDIR /app
-COPY --from=publish /app/publish .
+ARG APP_USER=appuser
+ARG APP_UID=10001
+RUN useradd -u ${APP_UID} ${APP_USER}
 
-COPY --from=build /app/Images /app/Images
+COPY --from=publish /app/publish .
+COPY Images /app/Images
+
+RUN chown -R ${APP_USER}:${APP_USER} /app/Images
+
+USER ${APP_USER}
+
 ENTRYPOINT ["dotnet", "ImageStoreAPI.dll"]

--- a/src/svc/image-store/Dockerfile
+++ b/src/svc/image-store/Dockerfile
@@ -17,15 +17,14 @@ RUN dotnet publish "./ImageStoreAPI.csproj" -c $BUILD_CONFIGURATION -o /app/publ
 
 FROM base AS final
 WORKDIR /app
-ARG APP_USER=appuser
-ARG APP_UID=10001
-RUN useradd -u ${APP_UID} ${APP_USER}
 
 COPY --from=publish /app/publish .
 COPY Images /app/Images
 
-RUN chown -R ${APP_USER}:${APP_USER} /app/Images
+USER root
+RUN chmod 777 /app/Images
+RUN chown -R $APP_UID /app/Images
 
-USER ${APP_USER}
+USER $APP_UID
 
 ENTRYPOINT ["dotnet", "ImageStoreAPI.dll"]


### PR DESCRIPTION
Dockerfile now correctly specifies non-root-user. Also now supports write to /Image folder.
Syncronization is still not implemented, needs to be looked upon in another PR!

**DOCKER FILE NOT UPLOADED TO GITHUB (YET)